### PR TITLE
Fixed Snapped Bug

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml
+++ b/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml
@@ -175,8 +175,7 @@
 			    SelectionMode="None"
                 helpers:ItemClickCommand.Command="{Binding ItemSelectedCommand}"
 			    IsSwipeEnabled="false"
-                IsItemClickEnabled="True"
-                ItemClick="ZoomedInItemGridView_ItemClick">
+                IsItemClickEnabled="True">
 
             <ListView.GroupStyle>
                 <GroupStyle>

--- a/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml.cs
@@ -84,10 +84,5 @@ namespace XPlatformCloudKit.Views
             ZoomedOutGroupGridView.ItemsSource = groupedItemsViewSource.View.CollectionGroups;
         }
 
-        private void ZoomedInItemGridView_ItemClick(object sender, ItemClickEventArgs e)
-        {
-            this.Frame.Navigate(typeof(ItemDescriptionView));
-        }
-
     }
 }


### PR DESCRIPTION
Removed the "ZoomedInItemGridView_ItemClick" method from the
ItemShowcaseview.xaml.cs to remove the bug caused by clicking an item in
snapped view.
