### PR TITLE
Added max item limit to RSS feeds

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.PCL/AppSettings.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.PCL/AppSettings.cs
@@ -45,6 +45,7 @@ namespace XPlatformCloudKit
 
         #region RssService Settings
         public const bool EnableRssService = true;//Use RssAddressCollection 
+        public const int RssMaxItemsPerFeed = 10; //The Maximum number of items to fetch for each feed. Enter Negative value to fetch all.
 
         //Urls to an RSS Data Source 
         //i.e. http://reddit.com/r/technology/.rss

--- a/XPlatformCloudKit/XPlatformCloudKit.PCL/DataServices/RssService.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.PCL/DataServices/RssService.cs
@@ -115,8 +115,11 @@ namespace XPlatformCloudKit.DataServices
             }
             else
             {
-                string audio_template = "<audio src=\"{0}\" controls autoplay>Your browser does not support the <code>audio</code> element.</audio><br/>";
-                items = from item in Feed.Descendants("item")
+                string audio_template = "<audio src=\"{0}\" controls autoplay>Your browser does not support the <code>audio</code> element.<br/><a href=\"{0}\">Link to file</a>.</audio><br/>";
+                var feeditems = AppSettings.RssMaxItemsPerFeed < 0
+                    ? Feed.Descendants("item")
+                    : Feed.Descendants("item").Take(AppSettings.RssMaxItemsPerFeed);
+                items = from item in feeditems
                         select new Item()
                         {
                             Title = item.Element("title") != null ? item.Element("title").Value : string.Empty,


### PR DESCRIPTION
Added RssMaxItemsPerFeed constant and the support to fetch only up to
that max number.

I added this as the first rss feed I tried not from the sample code had so many items I got out of memory errors.
