### PR TITLE
Fix for shortcut urls

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.PCL/DataServices/RssService.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.PCL/DataServices/RssService.cs
@@ -157,6 +157,10 @@ namespace XPlatformCloudKit.DataServices
                         if (AppSettings.ForceYoutubeVideosToLoadFullScreen)
                             item.Description = item.Description.Replace("/watch?v=", "/watch_popup?v=");
 
+                        // Fix "shortcut" urls
+                        item.Description = item.Description.Replace("src=\"//", "src=\"http://");
+                        item.Description = item.Description.Replace("src='//", "src='http://");
+
                         RssData.Add(item);
                     };
                 }


### PR DESCRIPTION
In modern browsers it is acceptable to use src urls that don't include
the protocol. e.g. src="//www.youtube.com" where http: is left off.
These shortcut urls will not render correctly in the WebView or
WebBrowser when using the NavigateToString method.
