### PR TITLE
Corrected extra day in Windows Phone trial calculation

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.Phone8/Views/ItemsShowcaseView.xaml.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Phone8/Views/ItemsShowcaseView.xaml.cs
@@ -93,7 +93,7 @@ namespace XPlatformCloudKit
                     if (fileStore.TryReadTextFile("FirstLaunch", out firstLaunch))
                     {
                         var dateTimeOfFirstLaunch = DateTime.Parse(firstLaunch);
-                        if ((DateTime.Now - dateTimeOfFirstLaunch).Days > AppSettings.TrialPeriodInDays)
+                        if ((DateTime.Now - dateTimeOfFirstLaunch).Days >= AppSettings.TrialPeriodInDays)
                         {
                             TrialBlocker.Visibility = Visibility.Visible;
                         }


### PR DESCRIPTION
Before this change setting AppSettings.TrialPeriodInDays to 1 actually
resulted in a trial of 2 days.
