### PR TITLE
Update ItemsShowcaseViewModel and RemoteAppSettingsTest

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.PCL/ViewModels/ItemsShowcaseViewModel.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.PCL/ViewModels/ItemsShowcaseViewModel.cs
@@ -39,6 +39,13 @@ namespace XPlatformCloudKit.ViewModels
             LoadItems(Debugger.IsAttached);
         }
 
+        public ItemsShowcaseViewModel(bool overrideCache)
+        {
+            //  If overrideCache is true, tell LoadItems() to ignore the cache, else if false, use the
+            //  cache. This allows for direct control of cache availability during testing.
+            LoadItems(overrideCache);
+        }
+
         #endregion // Constructors
 
         #region Internal Methods

--- a/XPlatformCloudKit/XPlatformCloudKit.Tests/RemoteAppSettingsTest.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Tests/RemoteAppSettingsTest.cs
@@ -35,7 +35,7 @@ namespace XPlatformCloudKit.Tests
         }
 
         [TestMethod]
-        public void ValidateRemoteAppSettingsServiceTest()
+        public void ValidateRemoteAppSettingsService()
         {
             Debug.WriteLine("Initial App Name = " + AppSettings.ApplicationName);
             Assert.IsFalse(AppSettings.ApplicationName.Contains("Remote Application"), "Application currently uses an inconclusive name of " + AppSettings.ApplicationName);
@@ -43,12 +43,13 @@ namespace XPlatformCloudKit.Tests
             AppSettings.EnableRemoteAppSettings = true;
             AppSettings.RemoteAppSettingsService = "http://pjdecarlo.com/playground/XPCKSampleRemoteAppSettings/AppSettings.html";
 
-            var itemsShowcaseViewModel = new ItemsShowcaseViewModel();
+            var itemsShowcaseViewModel = new ItemsShowcaseViewModel(true); // Ignore cache to retrieve AppSettings file from remote source
             MonitorLoadingItems(itemsShowcaseViewModel);
             Debug.WriteLine("Initial DataSources Loaded " + DateTime.Now.ToString());
 
             Debug.WriteLine("Final App Name = " + AppSettings.ApplicationName);
-            Assert.IsTrue(AppSettings.ApplicationName.Contains("Remote Application"), "Expected Remote Application Identifier not found");
+            Assert.IsTrue(AppSettings.ApplicationName.Contains("Remote Application"),
+                "Expected Remote Application Identifier not found."); // Will fail if invalid or no AppSettings file was retrieved
         }
 
         public static void MonitorLoadingItems(ItemsShowcaseViewModel itemsShowcaseViewModel)


### PR DESCRIPTION
I added another constructor under ItemsShowcaseViewModel to directly control cache availability. This allows testing of the validity of the AppSettings fetched from the remote source since it's brought into memory at test time. Since the cache is disabled, the test will override any recently retrieved, valid AppSettings that would otherwise give a false positive.
