### PR TITLE
Deregistered Share Link Event Handler

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemDescriptionView.xaml.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemDescriptionView.xaml.cs
@@ -84,6 +84,7 @@ namespace XPlatformCloudKit.Views
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             Windows.ApplicationModel.Search.SearchPane.GetForCurrentView().QuerySubmitted -= searchPane_QuerySubmitted;
+            DataTransferManager.GetForCurrentView().DataRequested -= ShareLinkHandler;
             base.OnNavigatedFrom(e);
         }
 

--- a/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemsShowcaseView.xaml.cs
@@ -44,7 +44,6 @@ namespace XPlatformCloudKit.Views
             this.NavigationCacheMode = Windows.UI.Xaml.Navigation.NavigationCacheMode.Enabled;
             this.InitializeComponent();
             SettingsPane.GetForCurrentView().CommandsRequested += ShowPrivacyPolicy;
-            DataTransferManager.GetForCurrentView().DataRequested += ShareLinkHandler;
             Loaded += ItemsShowcaseView_Loaded;
 
             if (AppSettings.EnableBackgroundWin8X == true)
@@ -166,5 +165,16 @@ namespace XPlatformCloudKit.Views
             }
         }
 
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            DataTransferManager.GetForCurrentView().DataRequested -= ShareLinkHandler;
+            base.OnNavigatedFrom(e);
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            DataTransferManager.GetForCurrentView().DataRequested += ShareLinkHandler;
+            base.OnNavigatedTo(e);
+        }
     }
 }


### PR DESCRIPTION
There was an issue with Windows 8.0 machines where an error would be thrown when navigating to any ItemDescriptionView. The problem was due to trying to register a new share contract event handler when the previous contract had not been deregistered.
