### PR TITLE
Share Link Event Handler Fix

### DIFF
--- a/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemDescriptionView.xaml.cs
+++ b/XPlatformCloudKit/XPlatformCloudKit.Win8/Views/ItemDescriptionView.xaml.cs
@@ -41,8 +41,7 @@ namespace XPlatformCloudKit.Views
 
         public ItemDescriptionView()
         {
-            this.InitializeComponent();
-            DataTransferManager.GetForCurrentView().DataRequested += ShareLinkHandler;
+            this.InitializeComponent();            
             Loaded += ItemDescriptionView_Loaded;
             //DataContext = new ItemDescriptionViewModel(); MVVMCross does not need to set DataContext!
             if (AppSettings.EnableBackgroundWin8X == true)
@@ -78,6 +77,7 @@ namespace XPlatformCloudKit.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            DataTransferManager.GetForCurrentView().DataRequested += ShareLinkHandler;
             Windows.ApplicationModel.Search.SearchPane.GetForCurrentView().QuerySubmitted += searchPane_QuerySubmitted;
             base.OnNavigatedTo(e);
         }


### PR DESCRIPTION
Registration of the share link event handler was still failing on
certain machine where the class initializer was being called before the
prior class' event handler could be deregistered. Moving registration to
the OnNavigatedTo section fixes this as it's always called after the
previous class' OnNavigatedFrom function.
